### PR TITLE
fix crash when setting a frequency > 5000 with enter

### DIFF
--- a/src/main/java/codechicken/wirelessredstone/core/GuiRedstoneWireless.java
+++ b/src/main/java/codechicken/wirelessredstone/core/GuiRedstoneWireless.java
@@ -302,9 +302,8 @@ public class GuiRedstoneWireless extends GuiScreenWidget implements IGuiRemoteUs
             if (itile == null)
                 item.setFreq(inventory.player, inventory.currentItem, inventory.getCurrentItem(), selectedfreq);
             else RedstoneEther.get(true).setFreq(itile, selectedfreq);
+            if (largeGui) reloadNameText();
         }
-
-        if (largeGui) reloadNameText();
     }
 
     private String getSetObjectName() {


### PR DESCRIPTION
Fix crash that occours when a frequency > 5000 is entered by moving the offending code behind canBroadcastOnFrequency which checks the bounds

stacktrace of crash
```
java.lang.ArrayIndexOutOfBoundsException: Index 5327 out of bounds for length 5001
    at codechicken.wirelessredstone.core.RedstoneEther.getFreqName(RedstoneEther.java:446)
    at codechicken.wirelessredstone.core.GuiRedstoneWireless.reloadNameText(GuiRedstoneWireless.java:236)
    at codechicken.wirelessredstone.core.GuiRedstoneWireless.setNewFreq(GuiRedstoneWireless.java:307)
    at codechicken.wirelessredstone.core.GuiRedstoneWireless.actionPerformed(GuiRedstoneWireless.java:261)
```

please note this fix is untested by me