### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/wrcbe_logic/lang/en_US.lang
+++ b/src/main/resources/assets/wrcbe_logic/lang/en_US.lang
@@ -1,3 +1,4 @@
+item.wrcbe_logic:wirelesspart.name=Wireless Device
 item.wrcbe_logic:wirelesspart|0.name=Wireless Transmitter
 item.wrcbe_logic:wirelesspart|1.name=Wireless Receiver
 item.wrcbe_logic:wirelesspart|2.name=Wireless Jammer


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.