### PR TITLE
Fix crash with unclamped wireless frequencies

### DIFF
--- a/src/main/java/codechicken/wirelessredstone/core/GuiRedstoneWireless.java
+++ b/src/main/java/codechicken/wirelessredstone/core/GuiRedstoneWireless.java
@@ -253,7 +253,7 @@ public class GuiRedstoneWireless extends GuiScreenWidget implements IGuiRemoteUs
             toggle = true;
         } else if (ident.equals("setFreq")) {
             try {
-                selectedfreq = Integer.parseInt(textboxfreq.getText());
+                selectedfreq = Math.max(0, Math.min(Integer.parseInt(textboxfreq.getText()), RedstoneEther.numfreqs));
             } catch (NumberFormatException e) {
                 // revert to previous selected frequency if number format is wrong somehow
                 textboxfreq.setText(String.valueOf(selectedfreq));


### PR DESCRIPTION
## Summary
Wireless Receivers/Transmitters prevent setting frequencies greater than 5000 with the in game buttons, but you can manually just type in a larger number and hit enter and the game will crash with an ArrayIndexOutOfBoundsException error. This just clamps whatever number you enter to the max limit (5000).

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
